### PR TITLE
Update HomeButton.podspec

### DIFF
--- a/HomeButton.podspec
+++ b/HomeButton.podspec
@@ -34,7 +34,7 @@ Add a working home button to your app for iPhone X users.
   s.source_files = 'HomeButton/Classes/**/*'
   
   s.resource_bundles = {
-    'HomeButton' => ['HomeButton/Assets/**/*.wav']
+    'HomeButton' => ['HomeButton/Assets/**/*.wav','HomeButton/Assets/**/*.png']
   }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'


### PR DESCRIPTION
Modern button styles require the png assets which aren't being copied into the target bundle when you install with Cocoapods.